### PR TITLE
Use data types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,28 +2,18 @@
 # MySQL orchestrator: For managing replication and failover.
 #
 class orchestrator (
-  $config            = $orchestrator::params::config,
-  $config_defaults   = $orchestrator::params::config_defaults,
-  $config_override   = {},
-  $config_template   = $orchestrator::params::config_template,
-  $package_ensure    = $orchestrator::params::package_ensure,
-  $package_manage    = $orchestrator::params::package_manage,
-  $package_name      = $orchestrator::params::package_name,
-  $service_enable    = $orchestrator::params::service_enable,
-  $service_ensure    = $orchestrator::params::service_ensure,
-  $service_manage    = $orchestrator::params::service_manage,
-  $service_name      = $orchestrator::params::service_name,
+  String  $config             = $orchestrator::params::config,
+  Hash    $config_defaults    = $orchestrator::params::config_defaults,
+  Hash    $config_override    = {},
+  String  $config_template    = $orchestrator::params::config_template,
+  String  $package_ensure     = $orchestrator::params::package_ensure,
+  Boolean $package_manage     = $orchestrator::params::package_manage,
+  Array[String] $package_name = $orchestrator::params::package_name,
+  Boolean $service_enable     = $orchestrator::params::service_enable,
+  Enum['running', 'stopped'] $service_ensure = $orchestrator::params::service_ensure,
+  Boolean $service_manage     = $orchestrator::params::service_manage,
+  String  $service_name       = $orchestrator::params::service_name,
 ) inherits orchestrator::params {
-
-  validate_absolute_path($config)
-  validate_string($config_template)
-  validate_string($package_ensure)
-  validate_bool($package_manage)
-  validate_array($package_name)
-  validate_bool($service_enable)
-  validate_string($service_ensure)
-  validate_bool($service_manage)
-  validate_string($service_name)
 
   # Based on https://github.com/puppetlabs/puppetlabs-ntp/blob/8db718ca76d05861b898e26764df1edb79bec989/manifests/init.pp#L65-L67
   #


### PR DESCRIPTION
This will update the module to use puppet's built in [data types](https://docs.puppet.com/puppet/latest/lang_data_type.html).

Not :100: on merging this or not. This would be incompatible with older versions of puppet.